### PR TITLE
fixing spelling mistake and turning logging off and on

### DIFF
--- a/src/aloha/aloha.hpp
+++ b/src/aloha/aloha.hpp
@@ -42,7 +42,7 @@ namespace aloha
 class aloha
 {
 public:
-    aloha(bool to_file=false) : m_to_file(to_file), m_timestamp(false)
+    aloha(bool to_file=false) : m_to_file(to_file), m_timestamp(false), m_logging(true)
     {
         if (to_file)
         {
@@ -51,7 +51,7 @@ public:
         }
     }
 
-    aloha(std::string file_path) : m_file_path(file_path), m_to_file(true), m_timestamp(false)
+    aloha(std::string file_path) : m_file_path(file_path), m_to_file(true), m_timestamp(false), m_logging(true)
     {
         outfile.open(file_path, std::ios_base::app);
     }
@@ -97,7 +97,7 @@ public:
         present_msg("fault", msg, error);
     }
 
-    void failur(std::string msg, bool error=false)
+    void failure(std::string msg, bool error=false)
     {
         present_msg("failur", msg, error);
     }
@@ -107,12 +107,30 @@ public:
         present_msg(type, msg, error);
     }
 
+    void logging_on()
+    {
+        m_logging = true;
+    }
+
+    void logging_off()
+    {
+        m_logging = false;
+    }
+
+    bool logging()
+    {
+        return m_logging;
+    }
+
 
 private:
 
     void present_msg(std::string type, std::string msg, bool error=false)
     {
-        write("[" + type + "] " + msg, error);
+        if (m_logging)
+        {
+            write("[" + type + "] " + msg, error);
+        }
     }
 
     void write(std::string msg, bool error=false)
@@ -163,6 +181,8 @@ private:
 
     bool m_to_file;
     bool m_timestamp;
+
+    bool m_logging;
 
     std::ofstream outfile;
 };

--- a/test/test_log_to_auto_file/test_log_auto_file.cpp
+++ b/test/test_log_to_auto_file/test_log_auto_file.cpp
@@ -15,7 +15,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failur("Testing failur");
+    log.failure("Testing failur");
 
     log.custom("custome", "Testing custom");
 
@@ -29,7 +29,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failur("Testing failur");
+    log.failure("Testing failur");
 
     log.custom("custom", "Testing");
 

--- a/test/test_log_to_cerr/test_log_to_cerr.cpp
+++ b/test/test_log_to_cerr/test_log_to_cerr.cpp
@@ -15,7 +15,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failur("Testing failur");
+    log.failure("Testing failur");
 
     log.custom("custom", "Testing custom");
 
@@ -27,7 +27,7 @@ int main(void)
     log.warning("Testing warning", true);
     log.error("Testing error", true);
     log.fault("Testing fault", true);
-    log.failur("Testing failur", true);
+    log.failure("Testing failur", true);
 
     log.custom("custom", "Testing", true);
 

--- a/test/test_log_to_custom_file/test_log_to_custom_file.cpp
+++ b/test/test_log_to_custom_file/test_log_to_custom_file.cpp
@@ -15,7 +15,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failur("Testing failur");
+    log.failure("Testing failur");
 
     log.custom("custome", "Testing custom");
 
@@ -29,7 +29,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failur("Testing failur");
+    log.failure("Testing failur");
 
     log.custom("custom", "Testing");
 

--- a/test/test_logging_on_off/test_logging_on_off.cpp
+++ b/test/test_logging_on_off/test_logging_on_off.cpp
@@ -15,7 +15,7 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failure("Testing failur");
+    log.failure("Testing failure");
 
     log.custom("custome", "Testing custom");
 
@@ -29,9 +29,33 @@ int main(void)
     log.warning("Testing warning");
     log.error("Testing error");
     log.fault("Testing fault");
-    log.failure("Testing failur");
+    log.failure("Testing failure");
 
     log.custom("custom", "Testing");
+
+    std::cout << "" << std::endl;
+    std::cout << "Turning logging off" << std::endl;
+    log.logging_off();
+    log.success("Testing success");
+    log.info("Testing info");
+    log.data("Testing data");
+
+    log.warning("Testing warning");
+    log.error("Testing error");
+    log.fault("Testing fault");
+    log.failure("Testing failure");
+
+    log.custom("custom", "Testing");
+    std::cout << "Turning logging back on off" << std::endl;
+    log.logging_on();
+    log.success("Testing success");
+    log.info("Testing info");
+    log.data("Testing data");
+
+    log.warning("Testing warning");
+    log.error("Testing error");
+    log.fault("Testing fault");
+    log.failure("Testing failure");
 
     return 0;
 }

--- a/test/test_logging_on_off/wscript
+++ b/test/test_logging_on_off/wscript
@@ -1,0 +1,5 @@
+def build(bld):
+    bld(features = 'cxx cxxprogram',
+        target = 'test_logging_on_off',
+        source = 'test_logging_on_off.cpp',
+        use = ['aloha_includes'])

--- a/wscript
+++ b/wscript
@@ -31,3 +31,4 @@ def build(bld):
     bld.recurse('test/test_log_to_custom_file')
     bld.recurse('test/test_log_to_iostream')
     bld.recurse('test/test_log_to_cerr')
+    bld.recurse('test/test_logging_on_off')    


### PR DESCRIPTION
I have fixed the a spelling mistake so the function `failur` now is `failure` and I have enabled it so it is possible to turn logging on and off 